### PR TITLE
Update pstream.h

### DIFF
--- a/work/include/pstream.h
+++ b/work/include/pstream.h
@@ -54,7 +54,7 @@ typedef struct program_stream_e_s {
     char				PackInfo1[2];
     unsigned char		stuffing_length;
 } program_stream_e;
-
+#pragma pack()
 #endif //__MEDIA_PSTREAM__H__
 
 


### PR DESCRIPTION
fixbug;字节对齐之后，在头文件结束要取消对齐，否则会有意想不到的内存错误